### PR TITLE
Update Tiltfile

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -5,7 +5,7 @@ NAME = "sample-app"
 
 k8s_custom_deploy(
   NAME,
-  apply_cmd="tanzu apps workload apply -f config/workload.yaml --live-update" +
+  apply_cmd="tanzu apps workload apply -f config/workload.yaml --debug --live-update" +
             " --local-path " + LOCAL_PATH +
             " --source-image " + SOURCE_IMAGE +
             " --namespace " + NAMESPACE +


### PR DESCRIPTION

Enable debug by default

This will not activate the debug functionality, but simply enable it such that we don't have to do another image build when/if the user activates tanzu debug