### PR TITLE
chore: update to consume new env var

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,6 +1,7 @@
 SOURCE_IMAGE = os.getenv("SOURCE_IMAGE", default='your-registry.io/project/steeltoe-weatherforecast-source') # update registry
 LOCAL_PATH = os.getenv("LOCAL_PATH", default='.')
 NAMESPACE = os.getenv("NAMESPACE", default='default')
+OUTPUT_TO_NULL_COMMAND = os.getenv("OUTPUT_TO_NULL_COMMAND", default=' > /dev/null ')
 NAME = "sample-app"
 
 k8s_custom_deploy(
@@ -9,7 +10,8 @@ k8s_custom_deploy(
             " --local-path " + LOCAL_PATH +
             " --source-image " + SOURCE_IMAGE +
             " --namespace " + NAMESPACE +
-            " --yes >/dev/null" +
+            " --yes" +
+            OUTPUT_TO_NULL_COMMAND +
             " && kubectl get workload " + NAME + " --namespace " + NAMESPACE + " -o yaml",
   delete_cmd="tanzu apps workload delete " + NAME + " --namespace " + NAMESPACE + " --yes",
   deps=['./bin'],

--- a/Tiltfile
+++ b/Tiltfile
@@ -10,7 +10,7 @@ k8s_custom_deploy(
             " --local-path " + LOCAL_PATH +
             " --source-image " + SOURCE_IMAGE +
             " --namespace " + NAMESPACE +
-            " --yes" +
+            " --yes " +
             OUTPUT_TO_NULL_COMMAND +
             " && kubectl get workload " + NAME + " --namespace " + NAMESPACE + " -o yaml",
   delete_cmd="tanzu apps workload delete " + NAME + " --namespace " + NAMESPACE + " --yes",


### PR DESCRIPTION
New env var will be set by IDE plugins to an OS-specific value. e.g. `> /dev/null` on *nix systems or `> $null` on Windows